### PR TITLE
Fix docstring typo

### DIFF
--- a/redblackgraph/reference/rbg_math.py
+++ b/redblackgraph/reference/rbg_math.py
@@ -12,7 +12,7 @@ def MSB(x: int) -> int:
 
 def avos_sum(x: int, y: int) -> int:
     '''
-    The avos sum is the non-zero minumum of x and y
+    The avos sum is the non-zero minimum of x and y
     :param x: operand 1
     :param y: operand 2
     :return: avos sum

--- a/redblackgraph/sparse/csgraph/_rbg_math.pxi
+++ b/redblackgraph/sparse/csgraph/_rbg_math.pxi
@@ -17,7 +17,7 @@ cdef inline bint avos_lt(DTYPE_t x, DTYPE_t y):
 
 cdef inline DTYPE_t avos_sum(DTYPE_t x, DTYPE_t y):
     '''
-    The avos sum is the non-zero minumum of x and y
+    The avos sum is the non-zero minimum of x and y
     :param x: operand 1
     :param y: operand 2
     :return: avos sum


### PR DESCRIPTION
## Summary
- correct typo in `avos_sum` docstring

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for numpy and redblackgraph.core._redblackgraph)*