### PR TITLE
Fix docstring typo

### DIFF
--- a/redblackgraph/reference/calc_relationship.py
+++ b/redblackgraph/reference/calc_relationship.py
@@ -25,7 +25,7 @@ def lookup_relationship(da: int, db: int) -> str:
     This is a very rudimentary implementation of a Consanguinity lookup and doesn't handle many
     cases correctly.
     :param da: generational distance from u to common ancestor
-    :param db: generational distance from v to common ancester
+    :param db: generational distance from v to common ancestor
     :return: a string designating relationship
     '''
     removal = abs(da - db)


### PR DESCRIPTION
## Summary
- fix spelling of `ancestor` in lookup_relationship docstring

## Testing
- `pytest -q` *(fails: No module named 'numpy')*