### PR TITLE
chore: update CI branch references from master to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ master, main, develop ]
+    branches: [ main, develop ]
   pull_request:
-    branches: [ master, main ]
+    branches: [ main ]
   workflow_dispatch:
 
 jobs:
@@ -147,7 +147,7 @@ jobs:
     name: Update Coverage Badge
     runs-on: ubuntu-latest
     needs: test
-    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main'
     permissions:
       contents: write
     


### PR DESCRIPTION
## Summary
- Remove `master` from `on.push.branches` and `on.pull_request.branches` in `.github/workflows/ci.yml`, keeping only `main` (and `develop` for push)
- Simplify the coverage-badge job `if` condition to only check for `refs/heads/main`
- No changes needed in `release.yml` (triggers on tags only) or `integration.yml` (no master references)
- `CLAUDE.md` had no master branch references

## Test plan
- [ ] Verify CI triggers correctly on pushes to `main` and `develop`
- [ ] Verify PR checks run on PRs targeting `main`
- [ ] Verify coverage badge updates on `main` branch pushes

🤖 Generated with [Claude Code](https://claude.com/claude-code)